### PR TITLE
Feat/aggregation

### DIFF
--- a/src/components/Execution/SingleNodeAggregation.jsx
+++ b/src/components/Execution/SingleNodeAggregation.jsx
@@ -19,13 +19,22 @@ export const SingleNodeAggregation = ({ node }) => {
     async () => {
       setIsWorking(true)
       // Create a tree with one contributor, nbShares aggregators and one finalizer
+      const finalAggregatorId = uuid()
       const parents = Array(nbShares)
         .fill()
         .map(() => ({
           level: 0,
+          aggregatorId: uuid(),
+          nbChild: 1,
           finalize: false,
           webhook: node.aggregationWebhook,
-          parents: [{ level: 1, webhook: node.aggregationWebhook, finalize: true }]
+          parent: {
+            level: 1,
+            aggregatorId: finalAggregatorId,
+            nbChild: nbShares,
+            webhook: node.aggregationWebhook,
+            finalize: true
+          }
         }))
       const contributionBody = {
         executionId: uuid(),
@@ -40,7 +49,7 @@ export const SingleNodeAggregation = ({ node }) => {
       )
       setIsWorking(false)
     },
-    [node, client, nbShares, setIsWorking]
+    [node, client, nbShares, pretrained, setIsWorking]
   )
 
   return (

--- a/src/targets/services/aggregation.js
+++ b/src/targets/services/aggregation.js
@@ -2,27 +2,38 @@ global.fetch = require('node-fetch').default
 global.btoa = require('btoa')
 
 import fs from 'fs'
-import CozyClient, { Q } from 'cozy-client'
-import { SHARES_DOCTYPE } from '../../doctypes'
+import CozyClient from 'cozy-client'
 import { Model } from './helpers'
 import dissecConfig from '../../../dissec.config.json'
+import { SHARES_DOCTYPE } from '../../../src/doctypes'
 
 export const aggregation = async () => {
   // Worker's arguments
-  const { docId, sharecode, uri, nbShares, parents, finalize, level, executionId } = JSON.parse(process.env['COZY_PAYLOAD'] || {})
+  const {
+    docId,
+    sharecode,
+    uri,
+    nbShares,
+    parent,
+    finalize,
+    level,
+    aggregatorId,
+    executionId,
+    nbChild
+  } = JSON.parse(process.env['COZY_PAYLOAD'] || {})
 
   // eslint-disable-next-line no-console
   console.log('aggregation received', process.env['COZY_PAYLOAD'])
 
   const client = CozyClient.fromEnv(process.env, {})
 
-  // 1. Download share using provided informations
+  // Download share using provided informations
   const sharedClient = new CozyClient({
     uri: uri,
     token: sharecode,
     schema: {
       files: {
-        doctype: "io.cozy.files",
+        doctype: 'io.cozy.files',
         relationships: {
           old_versions: {
             type: 'has-many',
@@ -33,35 +44,148 @@ export const aggregation = async () => {
     },
     store: false
   })
-  console.log("Requesting the share")
-  const share = await sharedClient.stackClient.fetchJSON('GET', `/files/download/${docId}`)
-  console.log(Object.keys(share))
-
-  // 2. Save the document
-
-  // 3. If some shares are missing, end now
-  if (data.length != nbShares) return
-
-  // 4. Fetch all stored shares
-  let shares = await Promise.all(
-    data.map(async e => {
-      const res = await client.query(Q(e.type)).where({ _id: e.id })
-      return res
-    })
+  const share = await sharedClient.stackClient.fetchJSON(
+    'GET',
+    `/files/download/${docId}`
   )
 
-  // 5. Compute sum or average if this node is the final aggregator
+  // Storing shares as files to be shared
+  // Create or find a DISSEC directory
+  const baseFolder = 'DISSEC'
+  let dissecDirectory
+  try {
+    const { data } = await client.stackClient.fetchJSON(
+      'POST',
+      `/files/io.cozy.files.root-dir?Type=directory&Name=${baseFolder}`
+    )
+    dissecDirectory = data.id
+  } catch (e) {
+    console.log('DISSEC folder already exists')
+    const { included } = await client.stackClient.fetchJSON(
+      'GET',
+      '/files/io.cozy.files.root-dir'
+    )
+    dissecDirectory = included.filter(
+      dir => dir.attributes.name === baseFolder
+    )[0].id
+  }
+
+  // Create a directory specifically for this aggregation
+  // This prevents mixing shares from different execution
+  let aggregationDirectory
+  try {
+    const { data } = await client.stackClient.fetchJSON(
+      'POST',
+      `/files/${dissecDirectory}?Type=directory&Name=${executionId}`
+    )
+    aggregationDirectory = data
+  } catch (e) {
+    console.log(
+      `Execution folder already exists, fetching ${dissecDirectory} instead`
+    )
+    const { included } = await client.stackClient.fetchJSON(
+      'GET',
+      `/files/${dissecDirectory}`
+    )
+    aggregationDirectory = included.filter(
+      dir => dir.attributes.name === executionId
+    )[0].id
+  }
+
+  // Fetch currently owned shares
+  console.log(`Fetching the content of folder ${aggregationDirectory}`)
+  const { included: allSharesReceived } = await client.stackClient.fetchJSON(
+    'GET',
+    `/files/${aggregationDirectory}`
+  )
+  // Filter only the shares for the aggregator in this position
+  const sharesReceived = allSharesReceived.filter(dir =>
+    dir.attributes.name.includes(`aggregator${aggregatorId}_level${level}`)
+  )
+  const received = sharesReceived.length
+  console.log(`Found ${received} shares`)
+
+  // Check if shares of each child has been received
+  if (received < nbChild - 1) {
+    // Some shares are missing
+    // Save the received share
+    console.log(`Aggregator ${aggregatorId} storing share ${received} while waiting for more`)
+    await client.stackClient.fetchJSON(
+      'POST',
+      `/files/${aggregationDirectory}?Type=file&Name=aggregator${aggregatorId}_level${level}_${sharecode}`,
+      share
+    )
+    // Wait for more shares
+    return
+  }
+
+  // Fetch all stored shares
+  const shares = [share]
+  for (let s of sharesReceived) {
+    console.log(`Downloading share ${received} `)
+    shares.push(
+      await client.stackClient.fetchJSON('GET', `/files/download/${s.id}`)
+    )
+  }
+
+  if (shares.length !== nbChild) throw 'Invalid number of shares received!'
+
+  // Combine the shares
   let model = Model.fromShares(shares, finalize)
 
   if (finalize) {
-    // 6. Write a file that will be used as a remote asset by the stack
+    // Write a file that will be used as a remote asset by the stack
     fs.writeFileSync(
       dissecConfig.localModelPath,
       JSON.stringify(model.getBackup())
     )
   } else {
-    // Call parent's aggregation webhook
+    // Store the aggregate as a file to be shared
+    const { data: aggregate } = await client.stackClient.fetchJSON(
+      'POST',
+      `/files/${aggregationDirectory}?Type=file&Name=aggregator${aggregatorId}_level${level}_aggregate${aggregatorId}`,
+      model.getBackup() // Backups are single shares with no noise
+    )
+
+    // Generate share code
+    const body = {
+      data: {
+        type: 'io.cozy.permissions',
+        attributes: {
+          source_id: aggregatorId,
+          permissions: {
+            shares: {
+              type: 'io.cozy.files',
+              verbs: ['GET', 'POST'],
+              values: [aggregate.id]
+            }
+          }
+        }
+      }
+    }
+    const { data: sharing } = await client.stackClient.fetchJSON(
+      'POST',
+      `/permissions?codes=parent${aggregatorId}&ttl=1h`,
+      body
+    )
+    const shareCode = sharing.attributes.shortcodes[`parent${aggregatorId}`]
+
+    // Call parent's aggregation webhook to send the aggregate
+    await client.stackClient.fetchJSON('POST', parent.webhook, {
+      executionId,
+      docId: aggregate.id,
+      sharecode: shareCode,
+      uri: client.stackClient.uri,
+      nbShares,
+      parent: parent.parent,
+      finalize: parent.finalize,
+      level: parent.level,
+      aggregatorId: parent.aggregatorId,
+      nbChild: parent.nbChild
+    })
   }
+
+  console.log('Finished execution of aggregation by', aggregatorId, '\n\n')
 }
 
 aggregation().catch(e => {

--- a/src/targets/services/contribution.js
+++ b/src/targets/services/contribution.js
@@ -71,7 +71,7 @@ export const contribution = async () => {
   for (let i in shares) {
     const { data: file } = await client.stackClient.fetchJSON(
       'POST',
-      `/files/${aggregationDirectory.id}?Type=file&Name=contribution-${i}`,
+      `/files/${aggregationDirectory.id}?Type=file&Name=contribution${i}`,
       shares[i]
     )
     files.push(file.id)
@@ -104,18 +104,22 @@ export const contribution = async () => {
   }
 
   // Call webhooks of parents with the share.
-  shareCodes.forEach(async (code, i) => {
+  for(let i in shareCodes) {
+    // HACK: Using a delay to give enough time to the responding service to store shares
+    await new Promise((resolve, ) => setTimeout(resolve, 5000))
     await client.stackClient.fetchJSON('POST', parents[i].webhook, {
       executionId,
       docId: files[i],
-      sharecode: code,
+      sharecode: shareCodes[i],
       uri: client.stackClient.uri,
       nbShares,
-      parents: parents[i].parents,
+      parent: parents[i].parent,
       finalize: parents[i].finalize,
-      level: parents[i].level
+      level: parents[i].level,
+      aggregatorId: parents[i].aggregatorId,
+      nbChild: parents[i].nbChild
     })
-  })
+  }
 }
 
 contribution().catch(e => {

--- a/src/targets/services/contribution.js
+++ b/src/targets/services/contribution.js
@@ -103,10 +103,10 @@ export const contribution = async () => {
     shareCodes.push(sharing.attributes.shortcodes[`aggregator${i}`])
   }
 
-  // Call webhooks of parents with the share.
-  for(let i in shareCodes) {
+  // Call webhooks of parents with the share
+  for (let i in shareCodes) {
     // HACK: Using a delay to give enough time to the responding service to store shares
-    await new Promise((resolve, ) => setTimeout(resolve, 5000))
+    await new Promise(resolve => setTimeout(resolve, 5000))
     await client.stackClient.fetchJSON('POST', parents[i].webhook, {
       executionId,
       docId: files[i],

--- a/src/targets/services/helpers/model.js
+++ b/src/targets/services/helpers/model.js
@@ -26,7 +26,6 @@ export class Model {
 
   static fromBackup(doc) {
     let model = new Model()
-    model.uniqueY = doc.uniqueY
     model.occurences = doc.occurences
     model.contributions = doc.contributions
     model.initialize()
@@ -142,10 +141,10 @@ export class Model {
   }
 
   getBackup() {
+    const { occurences, contributions } = this
     return {
-      occurences: this.occurences,
-      contributions: this.contributions,
-      uniqueY: this.uniqueY
+      occurences,
+      contributions
     }
   }
 }


### PR DESCRIPTION
This PR finishes the aggregation mechanism in the context of single node aggregation (one node plays all the different roles).
Unfortunately, as services are executed in parallel, a hack needed to be used:

The contribution service delays its calls to his parents (himself) to give the responding aggregation services enough time to process the share and store them. Otherwise, the different aggregators (played by the node) would see no shares stored and never trigggered the aggregation