### PR TITLE
Feat/less fetch json

### DIFF
--- a/scripts/webhooks.js
+++ b/scripts/webhooks.js
@@ -17,7 +17,7 @@ const main = async () => {
   })
 
   // Fetch triggers
-  const { data } = await client.stackClient.fetchJSON('GET', '/jobs/triggers')
+  const { data } = await client.collection('io.cozy.triggers').all()
 
   // Filter for webhooks
   let webhooks = data

--- a/scripts/webhooks.js
+++ b/scripts/webhooks.js
@@ -17,7 +17,7 @@ const main = async () => {
   })
 
   // Fetch triggers
-  const { data } = await client.collection('io.cozy.triggers').all()
+  const { data } = await client.queryAll(Q('io.cozy.triggers'))
 
   // Filter for webhooks
   let webhooks = data

--- a/src/components/Execution/Webhook.jsx
+++ b/src/components/Execution/Webhook.jsx
@@ -44,7 +44,7 @@ export const Webhook = ({ hook, onUpdate }) => {
   const handleRemoveWebhook = useCallback(
     async () => {
       setIsWorking(true)
-      await client.collection('io.cozy.trigggers').destroy(hook.link.self)
+      await client.destroy(hook)
       setIsWorking(false)
       onUpdate && onUpdate()
     },

--- a/src/components/Execution/Webhook.jsx
+++ b/src/components/Execution/Webhook.jsx
@@ -44,7 +44,7 @@ export const Webhook = ({ hook, onUpdate }) => {
   const handleRemoveWebhook = useCallback(
     async () => {
       setIsWorking(true)
-      await client.stackClient.fetchJSON('DELETE', hook.links.self)
+      await client.collection('io.cozy.trigggers').destroy(hook.link.self)
       setIsWorking(false)
       onUpdate && onUpdate()
     },

--- a/src/components/Execution/index.jsx
+++ b/src/components/Execution/index.jsx
@@ -31,7 +31,7 @@ export const Execution = ({ nodes }) => {
       const query = async name => {
         setIsWorking(true)
 
-        await client.collection('io.cozy.triggers').create({
+        await client.create('io.cozy.triggers', {
           type: '@webhook',
           worker: 'service',
           message: {

--- a/src/components/Execution/index.jsx
+++ b/src/components/Execution/index.jsx
@@ -31,16 +31,12 @@ export const Execution = ({ nodes }) => {
       const query = async name => {
         setIsWorking(true)
 
-        client.stackClient.fetchJSON('POST', '/jobs/triggers', {
-          data: {
-            attributes: {
-              type: '@webhook',
-              worker: 'service',
-              message: {
-                slug: 'dissecozy',
-                name: name
-              }
-            }
+        await client.collection('io.cozy.triggers').create({
+          type: '@webhook',
+          worker: 'service',
+          message: {
+            slug: 'dissecozy',
+            name: name
           }
         })
       }

--- a/src/targets/services/aggregation.js
+++ b/src/targets/services/aggregation.js
@@ -42,11 +42,8 @@ export const aggregation = async () => {
   // Fetch all stored shares
   const compressedShares = []
   for (let s of receivedShares) {
-    // TODO: Should use cozy-client, but fetchFileContentById returns a XMLHttpRequest that fails when parsed
-    const receivedShare = await client.stackClient.fetchJSON(
-      'GET',
-      `/files/download/${s._id}`
-    )
+    const response = await client.collection('io.cozy.files').fetchFileContentById(s._id)
+    const receivedShare = await response.text()
     compressedShares.push(receivedShare)
   }
 

--- a/src/targets/services/aggregation.js
+++ b/src/targets/services/aggregation.js
@@ -42,7 +42,7 @@ export const aggregation = async () => {
   // Fetch all stored shares
   const compressedShares = []
   for (let s of receivedShares) {
-    // TODO: Should use cozy-client, but fetchFileContentById uses fetch instead of fetchJSON
+    // TODO: Should use cozy-client, but fetchFileContentById returns a XMLHttpRequest that fails when parsed
     const receivedShare = await client.stackClient.fetchJSON(
       'GET',
       `/files/download/${s._id}`

--- a/src/targets/services/deleteOldShares.js
+++ b/src/targets/services/deleteOldShares.js
@@ -2,7 +2,7 @@ global.fetch = require('node-fetch').default
 
 import CozyClient, { Q } from 'cozy-client'
 
-import { createLogger, deleteFilesById, getAppDirectory } from './helpers'
+import { deleteFilesById, getAppDirectory } from './helpers'
 import config from '../../../dissec.config.json'
 
 /**
@@ -10,7 +10,6 @@ import config from '../../../dissec.config.json'
  */
 export const deleteOldShares = async () => {
   const client = CozyClient.fromEnv(process.env, {})
-  const log = createLogger(client.stackClient.uri)
   const appDirectory = await getAppDirectory(client)
 
   const { data: unfilteredFiles } = await client.query(
@@ -29,9 +28,7 @@ export const deleteOldShares = async () => {
     )
     .map(file => file.id)
 
-  await deleteFilesById(oldFileIds)
-
-  log(oldFileIds.length, 'old files have been deleted')
+  await deleteFilesById(client, oldFileIds)
 }
 
 deleteOldShares().catch(e => {

--- a/src/targets/services/receiveShares.js
+++ b/src/targets/services/receiveShares.js
@@ -42,13 +42,8 @@ export const receiveShares = async () => {
     store: false
   })
 
-  // TODO: Should use cozy-client, but fetchFileContentById returns a XMLHttpRequest that fails when parsed
-  const share = await sharedClient.stackClient.fetchJSON(
-    'GET',
-    `/files/download/${docId}`
-  )
-
-  log('Type of share', typeof share, Object.keys(blob), share)
+  const response = await sharedClient.collection('io.cozy.files').fetchFileContentById(docId)
+  const share = await response.text()
 
   const appDirectory = await getAppDirectory(client)
 

--- a/src/targets/services/receiveShares.js
+++ b/src/targets/services/receiveShares.js
@@ -42,13 +42,13 @@ export const receiveShares = async () => {
     store: false
   })
 
-  // TODO: Should use cozy-client, but fetchFileContentById uses fetch instead of fetchJSON
+  // TODO: Should use cozy-client, but fetchFileContentById returns a XMLHttpRequest that fails when parsed
   const share = await sharedClient.stackClient.fetchJSON(
     'GET',
     `/files/download/${docId}`
   )
 
-  log('Type of share', typeof share)
+  log('Type of share', typeof share, Object.keys(blob), share)
 
   const appDirectory = await getAppDirectory(client)
 


### PR DESCRIPTION
Replaced some `client.stackClient.fetchJSON` calls by the appropriate CozyClient method.

The remaining calls are for:

- Webhook triggering. There is currently no method for triggering them with CozyClient. It wouldn't make a lot of sense to have a dedicated method for that because it's just a `POST` HTTP request on a foreign instance: recreating a client for for the foreign instance would be overkill, and using `client.stackClient.fetchJSON` takes care of calling the right `fetch`
- Downloading files. I tried using `fetchFileContentById` but it returns a [`XMLHttpRequest`](https://developer.mozilla.org/fr/docs/Web/API/XMLHttpRequest) object. When calling methods to parse it (`blob` or `text`) on it, I get the error that the file does not exist