### PR TITLE
feat: Automatically loads webhooks upon populating

### DIFF
--- a/scripts/loadWebhooks.js
+++ b/scripts/loadWebhooks.js
@@ -2,9 +2,8 @@ global.fetch = require('node-fetch').default
 const fs = require('fs')
 const { default: CozyClient, Q } = require('cozy-client')
 
+const { NODES_DOCTYPE } = require('../src/doctypes/nodes')
 const newWebhooks = require('../assets/webhooks.json')
-
-const NODES_DOCTYPE = 'io.cozy.dissec.nodes'
 
 const main = async () => {
   // Connect to the instance
@@ -21,15 +20,13 @@ const main = async () => {
   })
 
   // Fetch old nodes
-  const { data: oldNodes } = await client.collection(NODES_DOCTYPE).all()
+  const { data: oldNodes } = await client.queryAll(Q(NODES_DOCTYPE))
 
   // Delete them
   await client.collection(NODES_DOCTYPE).destroyAll(oldNodes)
 
   // Create a new doc for each instance
-  for(const webhook of newWebhooks) {
-    await client.collection(NODES_DOCTYPE).create(webhook)
-  }
+  await client.collection(NODES_DOCTYPE).saveAll(newWebhooks)
 }
 
 main()

--- a/scripts/loadWebhooks.js
+++ b/scripts/loadWebhooks.js
@@ -1,0 +1,35 @@
+global.fetch = require('node-fetch').default
+const fs = require('fs')
+const { default: CozyClient, Q } = require('cozy-client')
+
+const newWebhooks = require('../assets/webhooks.json')
+
+const NODES_DOCTYPE = 'io.cozy.dissec.nodes'
+
+const main = async () => {
+  // Connect to the instance
+  const client = new CozyClient({
+    uri: process.argv[2],
+    schema: {
+      nodes: {
+        doctype: NODES_DOCTYPE,
+        attributes: {},
+        relationships: {}
+      }
+    },
+    token: process.argv[3]
+  })
+
+  // Fetch old nodes
+  const { data: oldNodes } = await client.collection(NODES_DOCTYPE).all()
+
+  // Delete them
+  await client.collection(NODES_DOCTYPE).destroyAll(oldNodes)
+
+  // Create a new doc for each instance
+  for(const webhook of newWebhooks) {
+    await client.collection(NODES_DOCTYPE).create(webhook)
+  }
+}
+
+main()

--- a/scripts/populate.sh
+++ b/scripts/populate.sh
@@ -35,3 +35,7 @@ do
     # Fetch webhooks
     node ./scripts/webhooks.js http://${domain} ${token} ./assets/webhooks.json
 done
+
+# Upload new instances webhooks to the querier instance
+token=$(cozy-stack instances token-app cozy.localhost:8080 dissecozy)
+node ./scripts/loadWebhooks.js http://cozy.localhost:8080 ${token}

--- a/scripts/webhooks.js
+++ b/scripts/webhooks.js
@@ -1,6 +1,6 @@
 global.fetch = require('node-fetch').default
 const fs = require('fs')
-const { default: CozyClient, Q } = require('cozy-client')
+const { default: CozyClient } = require('cozy-client')
 
 const main = async () => {
   // Connect to the instance


### PR DESCRIPTION
"Manually" creating `io.cozy.dissec.nodes` documents when new instances have been created is no longer required.

Old process:
1. run `yarn populate`
2. Open the Nodes page of the front-end
3. Import JSON of the webhooks
4. Click Upload

Now:
1. Run `yarn populate`